### PR TITLE
[RED-2737] Bugfixes for A100 instance

### DIFF
--- a/vla-scripts/finetune.py
+++ b/vla-scripts/finetune.py
@@ -119,7 +119,6 @@ def finetune(cfg: FinetuneConfig) -> None:
     distributed_state = PartialState()
     torch.cuda.set_device(device_id := distributed_state.local_process_index)
     torch.cuda.empty_cache()
-    dist.init_process_group(backend='nccl', init_method='env://')
 
     # Configure Unique Experiment ID & Log Directory
     exp_id = (

--- a/vla-scripts/finetune.py
+++ b/vla-scripts/finetune.py
@@ -119,6 +119,7 @@ def finetune(cfg: FinetuneConfig) -> None:
     distributed_state = PartialState()
     torch.cuda.set_device(device_id := distributed_state.local_process_index)
     torch.cuda.empty_cache()
+    dist.init_process_group(backend='nccl', init_method='env://')
 
     # Configure Unique Experiment ID & Log Directory
     exp_id = (

--- a/vla-scripts/finetune.py
+++ b/vla-scripts/finetune.py
@@ -183,6 +183,7 @@ def finetune(cfg: FinetuneConfig) -> None:
         vla.print_trainable_parameters()
 
     # Wrap VLA in PyTorch DDP Wrapper for Multi-GPU Training
+    dist.init_process_group(backend='nccl', init_method='env://')  # must be called before DDP(...)
     vla = DDP(vla, device_ids=[device_id], find_unused_parameters=True, gradient_as_bucket_view=True)
 
     # Create Optimizer =>> note that we default to a simple constant learning rate!


### PR DESCRIPTION
Need to call init_process_group before `DDP(...)`, apparently. Otherwise get:
```
ValueError: Default process group has not been initialized, please make sure to call init_process_group.
```